### PR TITLE
CI/CD pipeline to build, tag and publish apptainer container

### DIFF
--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -26,8 +26,6 @@ run-name: tag-container-push
 
 on:
   workflow_call:
-  # For testing purposes
-  push:
   
 jobs:
   tag-container-push:


### PR DESCRIPTION
This PR adds the creation of an apptainer container image to the CI/CD pipeline. Previously, the pipeline created a version-tagged docker container every commit and published it on GitHub in the package namespace for the repo [here](https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer). Now, a version-tagged _apptainer_ container is _also_ created and published every commit in a different package namespace for the repo [here](https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer-sif). I emphasise that the package namespace for the docker containers and the apptainer containers are different: `data-transfer` and `data-transfer-sif`, respectively.

https://github.com/PSDI-UK/data-transfer-container/actions/runs/13696731198/job/38300743845 shows that the pipeline works as expected. (This pipeline was triggered by a previous commit in this PR which is identical to the current state of the code, except that `tag-container-push.yml` was set to be triggered every push - a condition which I have now disabled). The existence of docker and apptainer container images linked to this branch [here](https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer) and [here](https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer-sif) is further evidence that the pipeline works. 

If one wants to test that the apptainer containers work, then the command to pull them from this repo is, e.g. `apptainer pull oras://ghcr.io/psdi-uk/data-transfer-container/data-transfer-sif:v0.0.11-psdi-405-cicd-pipeline-to-build-apptainer-container.8`. I have done this, and run the container locally, and it works okay (though admittedly my testing was shallow).

This PR completes Jira issue https://stfc.atlassian.net/browse/PSDI-405 - except perhaps documentation of how to use and obtain the apptainer container, since the user guide for the container is currently not housed in this repository.