### PR TITLE
Implement 'latest' tag for docker and apptainer container images

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -17,5 +17,6 @@ jobs:
     # NOTE: The dependency on 'anchore-scan' has been disabled for now; see
     #       the above comment regarding 'anchore-scan' for further info.
     #needs: [anchore-scan]
-    if: github.ref == 'refs/heads/main'
+    #TODO: Restore this after testing is complete
+    #if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -6,17 +6,12 @@ on:
   
 jobs:
 
-  # NOTE: 'anchore-scan' is disabled for now since it is only supported on
-  #       public repos with the free GitHub plan. 
-  #anchore-scan:
-  #  uses: ./.github/workflows/anchore-scan.yml
-  #  if: github.ref == 'refs/heads/main'
+  anchore-scan:
+    uses: ./.github/workflows/anchore-scan.yml
+    if: github.ref == 'refs/heads/main'
 
   tag-container-push:
     uses: ./.github/workflows/tag-container-push.yml
-    # NOTE: The dependency on 'anchore-scan' has been disabled for now; see
-    #       the above comment regarding 'anchore-scan' for further info.
-    #needs: [anchore-scan]
-    #TODO: Restore this after testing is complete
-    #if: github.ref == 'refs/heads/main'
+    needs: [anchore-scan]
+    if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -69,11 +69,12 @@ jobs:
         run: |
           docker build -t $DOCKER_IMAGE_NAME:$TAG .
           docker push $DOCKER_IMAGE_NAME:$TAG
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-            docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
-            docker push $DOCKER_IMAGE_NAME:latest
-          fi
+          #TODO: Restore this if block after testing is complete
+          #if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+          docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
+          docker push $DOCKER_IMAGE_NAME:latest
+          #fi
       - name: Install Apptainer
         run: |
           sudo apt install -y software-properties-common
@@ -89,7 +90,8 @@ jobs:
         run: |
           apptainer build container.sif docker-daemon://$DOCKER_IMAGE_NAME:$TAG
           apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:$TAG
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-            apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
-          fi
+          #TODO: Restore this if block after testing is complete
+          #if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+          apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
+          #fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -61,12 +61,19 @@ jobs:
         env: # needed to authenticate to github and download the repo
           GIT_USERNAME: ${{ github.actor }}
           GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker build API
+      - name: Build and push Docker image with version tags
         env:
-          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer:${{ steps.tag_version.outputs.new_tag }}"
+          # Note that this is the name of the image *without the tag*
+          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer"
+          TAG: ${{ steps.tag_version.outputs.new_tag }}
         run: |
-          docker build -t $DOCKER_IMAGE_NAME .
-          docker push $DOCKER_IMAGE_NAME
+          docker build -t $DOCKER_IMAGE_NAME:$TAG .
+          docker push $DOCKER_IMAGE_NAME:$TAG
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
+            docker push $DOCKER_IMAGE_NAME:latest
+          fi
       - name: Install Apptainer
         run: |
           sudo apt install -y software-properties-common
@@ -75,8 +82,14 @@ jobs:
           apptainer --version
       - name: Build Apptainer image from the Docker image
         env:
-          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer:${{ steps.tag_version.outputs.new_tag }}"
-          APPTAINER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer-sif:${{ steps.tag_version.outputs.new_tag }}"
+          # Note that these are the names of the images *without the tag*
+          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer"
+          APPTAINER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer-sif"
+          TAG: ${{ steps.tag_version.outputs.new_tag }}
         run: |
-          apptainer build container.sif docker-daemon://$DOCKER_IMAGE_NAME
-          apptainer push container.sif oras://$APPTAINER_IMAGE_NAME
+          apptainer build container.sif docker-daemon://$DOCKER_IMAGE_NAME:$TAG
+          apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:$TAG
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
+          fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -1,12 +1,17 @@
 #
 # This action does the following:
 # 1) Creates a new release containing the repository source code, tagging the
-#    release with an appropriate version number, and publishing it on the Github project
+#    release with an appropriate version tag, and publishing it on the GitHub project
 #    page
-# 2) Build a docker container image, tagging the release with an appropriate version number,
-#    and publishing it on the Github project page
-# 3) Build an apptainer container image, tagging the release with an appropriate version number,
-#    and publishing it on the Github project page
+# 2) Build a docker container image, tagging the release with an appropriate version tag,
+#    and publishing it on the GitHub project page
+# 3) Build an apptainer container image, tagging the release with an appropriate version tag,
+#    and publishing it on the GitHub project page
+# 4) If the version tag for an image matches the regex '^v[0-9]+\.[0-9]+\.[0-9]+$', i.e. it
+#    corresponds to a 'release' version, then additionally tag the container image with the
+#    'latest' tag and publish it on the GitHub project page. Note that this applies to
+#    both docker and apptainer images
+#
 #
 # Notes:
 # - The version number is incremented every release as described in
@@ -69,19 +74,18 @@ jobs:
         run: |
           docker build -t $DOCKER_IMAGE_NAME:$TAG .
           docker push $DOCKER_IMAGE_NAME:$TAG
-          #TODO: Restore this if block after testing is complete
-          #if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-          docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
-          docker push $DOCKER_IMAGE_NAME:latest
-          #fi
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
+            docker push $DOCKER_IMAGE_NAME:latest
+          fi
       - name: Install Apptainer
         run: |
           sudo apt install -y software-properties-common
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt install -y apptainer
           apptainer --version
-      - name: Build Apptainer image from the Docker image
+      - name: Build Apptainer image from the Docker image and push with version tags
         env:
           # Note that these are the names of the images *without the tag*
           DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/data-transfer-container/data-transfer"
@@ -90,8 +94,7 @@ jobs:
         run: |
           apptainer build container.sif docker-daemon://$DOCKER_IMAGE_NAME:$TAG
           apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:$TAG
-          #TODO: Restore this if block after testing is complete
-          #if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-          apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
-          #fi
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
+          fi


### PR DESCRIPTION
In this PR I modify the CI/CD pipeline so that whenever a container image is published in the container registry for this repo, and the tag for the container image is of the form `v*.*.*` (where `*` are non-negative integers), the container image is additionally given the 'latest' tag. This is the case for both the docker and the apptainer images generated by the CI/CD pipeline.

Moreover, in this PR I have also activated security scans via the `anchore-scan` job in the CI/CD pipeline. This had been deactivated while the repository was private. However, now that the repo has recently been made public, the scans can be used. Note though that they will only run in the `main` branch, so no scans will run until this PR is merged.

Evidence that the pipeline can generate a 'latest' tag successfully can be found at:
-  https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer for the docker images
- https://github.com/PSDI-UK/data-transfer-container/pkgs/container/data-transfer-container%2Fdata-transfer-sif for the apptainer images

Note that in both cases the 'latest' tag can be seen to be in operation. However, in this case to generate the 'latest' tag I - for testing purposes - disabled the check that the tag has the form `v*.*.*`. (The job which generated the 'latest' tag here is https://github.com/PSDI-UK/data-transfer-container/actions/runs/14129397837/job/39585746845). When the PR is merged the pipeline will have the desired behaviour: 'latest' tags will only be generated for container images which have tags of the form `v*.*.*`.

This PR completes the part of https://stfc.atlassian.net/browse/PSDI-477 pertaining to the `data-transfer-container` repo.